### PR TITLE
Implement Song Service

### DIFF
--- a/resource-service/src/main/java/com/epam/resourceservice/controller/ResourceController.java
+++ b/resource-service/src/main/java/com/epam/resourceservice/controller/ResourceController.java
@@ -48,8 +48,9 @@ public class ResourceController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteResources(@RequestParam List<Integer> ids) {
+    public ResponseEntity<Map<String, List<Integer>>> deleteResources(@RequestParam List<Integer> ids) {
         resourceService.deleteByIds(ids);
-        return ResponseEntity.noContent().build();
+        var responseBody = Map.of("ids", ids);
+        return ResponseEntity.ok(responseBody);
     }
 }

--- a/resource-service/src/test/resources/ResourceServiceTest.http
+++ b/resource-service/src/test/resources/ResourceServiceTest.http
@@ -18,4 +18,4 @@ Content-Type: audio/mpeg
 GET {{host}}/resources/1
 
 ### Delete the resources with IDs 1 and 2
-DELETE {{host}}/resources?id=1,2
+DELETE {{host}}/resources?ids=1,2

--- a/song-service/src/main/java/com/epam/songservice/controller/SongController.java
+++ b/song-service/src/main/java/com/epam/songservice/controller/SongController.java
@@ -1,0 +1,43 @@
+package com.epam.songservice.controller;
+
+import com.epam.songservice.model.Song;
+import com.epam.songservice.service.SongService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/songs")
+public class SongController {
+
+    private final SongService songService;
+
+    @Autowired
+    public SongController(SongService songService) {
+        this.songService = songService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Song> createSong(@RequestBody Song song) {
+        Song savedSong = songService.save(song);
+        return ResponseEntity.ok(savedSong);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Song> getSong(@PathVariable Integer id) {
+        Song song = songService.findById(id);
+        if (song == null) {
+            return ResponseEntity.notFound().build();
+        } else {
+            return ResponseEntity.ok(song);
+        }
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteSongs(@RequestParam List<Integer> ids) {
+        songService.deleteByIds(ids);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/song-service/src/main/java/com/epam/songservice/controller/SongController.java
+++ b/song-service/src/main/java/com/epam/songservice/controller/SongController.java
@@ -4,7 +4,14 @@ import com.epam.songservice.model.Song;
 import com.epam.songservice.service.SongService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
@@ -31,7 +38,9 @@ public class SongController {
     public ResponseEntity<Song> getSong(@PathVariable Integer id) {
         return songService.findById(id)
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                .orElse(ResponseEntity.notFound()
+                        .header("Error", "Song with ID " + id + " not found")
+                        .build());
     }
 
     @DeleteMapping

--- a/song-service/src/main/java/com/epam/songservice/controller/SongController.java
+++ b/song-service/src/main/java/com/epam/songservice/controller/SongController.java
@@ -29,12 +29,9 @@ public class SongController {
 
     @GetMapping("/{id}")
     public ResponseEntity<Song> getSong(@PathVariable Integer id) {
-        Song song = songService.findById(id);
-        if (song == null) {
-            return ResponseEntity.notFound().build();
-        } else {
-            return ResponseEntity.ok(song);
-        }
+        return songService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @DeleteMapping

--- a/song-service/src/main/java/com/epam/songservice/controller/SongController.java
+++ b/song-service/src/main/java/com/epam/songservice/controller/SongController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/songs")
@@ -20,9 +21,10 @@ public class SongController {
     }
 
     @PostMapping
-    public ResponseEntity<Song> createSong(@RequestBody Song song) {
-        Song savedSong = songService.save(song);
-        return ResponseEntity.ok(savedSong);
+    public ResponseEntity<Map<String, Integer>> createSong(@RequestBody Song song) {
+        var savedSong = songService.save(song);
+        var responseBody = Map.of("id", savedSong.getId());
+        return ResponseEntity.ok(responseBody);
     }
 
     @GetMapping("/{id}")
@@ -36,8 +38,9 @@ public class SongController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteSongs(@RequestParam List<Integer> ids) {
+    public ResponseEntity<Map<String, List<Integer>>> deleteSongs(@RequestParam List<Integer> ids) {
         songService.deleteByIds(ids);
-        return ResponseEntity.noContent().build();
+        var responseBody = Map.of("ids", ids);
+        return ResponseEntity.ok(responseBody);
     }
 }

--- a/song-service/src/main/java/com/epam/songservice/model/Song.java
+++ b/song-service/src/main/java/com/epam/songservice/model/Song.java
@@ -1,0 +1,95 @@
+package com.epam.songservice.model;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "songs")
+public class Song {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+    private String artist;
+    private String album;
+    private String length;
+    private String resourceId;
+    private String year;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getArtist() {
+        return artist;
+    }
+
+    public void setArtist(String artist) {
+        this.artist = artist;
+    }
+
+    public String getAlbum() {
+        return album;
+    }
+
+    public void setAlbum(String album) {
+        this.album = album;
+    }
+
+    public String getLength() {
+        return length;
+    }
+
+    public void setLength(String length) {
+        this.length = length;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public String getYear() {
+        return year;
+    }
+
+    public void setYear(String year) {
+        this.year = year;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Song song = (Song) o;
+        return Objects.equals(id, song.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/song-service/src/main/java/com/epam/songservice/package-info.java
+++ b/song-service/src/main/java/com/epam/songservice/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * This package contains the Song Service, a microservice for managing song metadata.
+ * The Song Service provides CRUD operations for song metadata records, including the ability
+ * to create new records, retrieve existing records by ID, and delete records.
+ * It communicates with the Resource Service to associate song metadata with MP3 resources.
+ */
+@NonNullApi
+package com.epam.songservice;
+
+import org.springframework.lang.NonNullApi;

--- a/song-service/src/main/java/com/epam/songservice/repository/SongRepository.java
+++ b/song-service/src/main/java/com/epam/songservice/repository/SongRepository.java
@@ -1,0 +1,7 @@
+package com.epam.songservice.repository;
+
+import com.epam.songservice.model.Song;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SongRepository extends JpaRepository<Song, Integer> {
+}

--- a/song-service/src/main/java/com/epam/songservice/service/SongService.java
+++ b/song-service/src/main/java/com/epam/songservice/service/SongService.java
@@ -1,0 +1,31 @@
+package com.epam.songservice.service;
+
+import com.epam.songservice.model.Song;
+import com.epam.songservice.repository.SongRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class SongService {
+
+    private final SongRepository songRepository;
+
+    @Autowired
+    public SongService(SongRepository songRepository) {
+        this.songRepository = songRepository;
+    }
+
+    public Song save(Song song) {
+        return songRepository.save(song);
+    }
+
+    public Song findById(Integer id) {
+        return songRepository.findById(id).orElse(null);
+    }
+
+    public void deleteByIds(List<Integer> ids) {
+        songRepository.deleteAllById(ids);
+    }
+}

--- a/song-service/src/main/java/com/epam/songservice/service/SongService.java
+++ b/song-service/src/main/java/com/epam/songservice/service/SongService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class SongService {
@@ -21,8 +22,8 @@ public class SongService {
         return songRepository.save(song);
     }
 
-    public Song findById(Integer id) {
-        return songRepository.findById(id).orElse(null);
+    public Optional<Song> findById(Integer id) {
+        return songRepository.findById(id);
     }
 
     public void deleteByIds(List<Integer> ids) {

--- a/song-service/src/test/resources/SongServiceTest.http
+++ b/song-service/src/test/resources/SongServiceTest.http
@@ -1,0 +1,20 @@
+@host = http://localhost:8080
+
+### Create a new song
+POST {{host}}/songs
+Content-Type: application/json
+
+{
+  "name": "We are the champions",
+  "artist": "Queen",
+  "album": "News of the world",
+  "length": "2:59",
+  "resourceId": "123",
+  "year": "1977"
+}
+
+### Get the song with ID 1
+GET {{host}}/songs/1
+
+### Delete the songs with IDs 1 and 2
+DELETE {{host}}/songs?ids=1,2


### PR DESCRIPTION
This pull request includes the implementation of the Song Service, which is part of the 'Introduction to Microservices' coursework at EPAM.

The Song Service is a Spring Boot application that provides CRUD operations for song metadata. It communicates with the Resource Service to associate song metadata with MP3 resources.

The following features have been implemented:

- A `Song` entity that represents song metadata in the database.
- A `SongRepository` that extends `JpaRepository` for performing CRUD operations on `Song` entities.
- A `SongService` that uses the `SongRepository` to perform operations on songs.
- A `SongController` that exposes the operations of the `SongService` as RESTful endpoints.

The application can be run using the command `./mvnw spring-boot:run`. It connects to a PostgreSQL database running in a Docker container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Song Service for managing song metadata, including endpoints for creating, retrieving, and deleting songs.
  - Added entity class for Song with properties like id, name, artist, album, length, resourceId, and year.

- **Bug Fixes**
  - Corrected URL parameter typo in resource deletion endpoint from `id` to `ids`.

- **Improvements**
  - Updated response structure for resource deletion to return a map with deleted IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->