### PR TITLE
Add song metadata extraction and uploading feature

### DIFF
--- a/resource-service/pom.xml
+++ b/resource-service/pom.xml
@@ -15,6 +15,7 @@
     <description>resource-service</description>
     <properties>
         <java.version>21</java.version>
+        <tika.version>2.9.0</tika.version>
     </properties>
     <dependencies>
         <dependency>
@@ -26,6 +27,16 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>${tika.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers-standard-package</artifactId>
+            <version>${tika.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>

--- a/resource-service/src/main/java/com/epam/resourceservice/config/AppConfig.java
+++ b/resource-service/src/main/java/com/epam/resourceservice/config/AppConfig.java
@@ -1,0 +1,37 @@
+package com.epam.resourceservice.config;
+
+import com.epam.resourceservice.core.SongMetadataExtractor;
+import com.epam.resourceservice.core.TikaMetadataExtractor;
+import com.epam.resourceservice.core.SongMetadataMapper;
+import org.apache.tika.metadata.Metadata;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+import java.util.function.Function;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public Function<MultipartFile, Metadata> mp3MetadataExtractor() {
+        return new TikaMetadataExtractor();
+    }
+
+    @Bean
+    public Function<Metadata, Map<String, String>> songMetadataMapper() {
+        return new SongMetadataMapper();
+    }
+
+    @Bean
+    public Function<MultipartFile, Map<String, String>> songInfoExtractor() {
+        return mp3MetadataExtractor().andThen(songMetadataMapper());
+    }
+}

--- a/resource-service/src/main/java/com/epam/resourceservice/controller/ResourceController.java
+++ b/resource-service/src/main/java/com/epam/resourceservice/controller/ResourceController.java
@@ -5,9 +5,14 @@ import com.epam.resourceservice.service.ResourceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -17,8 +22,8 @@ import java.util.Map;
 @RestController
 @RequestMapping("/resources")
 public class ResourceController {
-    Logger logger = LoggerFactory.getLogger(ResourceController.class);
     private final ResourceService resourceService;
+    Logger logger = LoggerFactory.getLogger(ResourceController.class);
 
     @Autowired
     public ResourceController(ResourceService resourceService) {
@@ -26,15 +31,8 @@ public class ResourceController {
     }
 
     @PostMapping
-    public ResponseEntity<Map<String, Integer>> uploadResource(@RequestParam("file") MultipartFile file) {
-        var resource = new Resource();
-        try {
-            resource.setData(file.getBytes());
-        } catch (IOException e) {
-            logger.warn(e.getMessage());
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
-        var savedResource = resourceService.save(resource);
+    public ResponseEntity<Map<String, Integer>> uploadResource(@RequestParam("file") MultipartFile file) throws IOException {
+        var savedResource = resourceService.save(file);
         var responseBody = Map.of("id", savedResource.getId());
         return ResponseEntity.ok(responseBody);
     }

--- a/resource-service/src/main/java/com/epam/resourceservice/core/SongMetadataExtractor.java
+++ b/resource-service/src/main/java/com/epam/resourceservice/core/SongMetadataExtractor.java
@@ -1,0 +1,10 @@
+package com.epam.resourceservice.core;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface SongMetadataExtractor extends Function<MultipartFile, Map<String, String>> {
+}

--- a/resource-service/src/main/java/com/epam/resourceservice/core/SongMetadataMapper.java
+++ b/resource-service/src/main/java/com/epam/resourceservice/core/SongMetadataMapper.java
@@ -1,0 +1,30 @@
+package com.epam.resourceservice.core;
+
+import org.apache.tika.metadata.Metadata;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class SongMetadataMapper implements Function<Metadata, Map<String, String>> {
+    private static final String NAME = "title";
+    private static final String ARTIST = "xmpDM:artist";
+    private static final String ALBUM = "xmpDM:album";
+    private static final String LENGTH = "xmpDM:duration";
+    private static final String YEAR = "xmpDM:releaseDate";
+
+    @Override
+    public Map<String, String> apply(Metadata metadata) {
+        return Map.of(
+                "name", getOrDefault(metadata, NAME),
+                "artist", getOrDefault(metadata, ARTIST),
+                "album", getOrDefault(metadata, ALBUM),
+                "length", getOrDefault(metadata, LENGTH),
+                "year", getOrDefault(metadata, YEAR)
+        );
+    }
+
+    private String getOrDefault(Metadata metadata, String key) {
+        String value = metadata.get(key);
+        return value != null ? value : "";
+    }
+}

--- a/resource-service/src/main/java/com/epam/resourceservice/core/TikaMetadataExtractor.java
+++ b/resource-service/src/main/java/com/epam/resourceservice/core/TikaMetadataExtractor.java
@@ -1,0 +1,23 @@
+package com.epam.resourceservice.core;
+
+import org.apache.tika.Tika;
+import org.apache.tika.metadata.Metadata;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+public class TikaMetadataExtractor implements Function<MultipartFile, Metadata> {
+
+    @Override
+    public Metadata apply(MultipartFile multipartFile) {
+        var tika = new Tika();
+        var metadata = new Metadata();
+        try {
+            tika.parse(multipartFile.getInputStream(), metadata);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return metadata;
+    }
+}

--- a/resource-service/src/main/java/com/epam/resourceservice/service/ResourceService.java
+++ b/resource-service/src/main/java/com/epam/resourceservice/service/ResourceService.java
@@ -1,21 +1,50 @@
 package com.epam.resourceservice.service;
 
+import com.epam.resourceservice.core.SongMetadataExtractor;
+import com.epam.resourceservice.core.SongMetadataMapper;
 import com.epam.resourceservice.model.Resource;
 import com.epam.resourceservice.repository.ResourceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 @Service
 public class ResourceService {
 
     private final ResourceRepository resourceRepository;
+    private final Function<MultipartFile, Map<String, String>> mp3MetadataExtractor;
+    private final RestTemplate restTemplate;
+    private final String songServiceUrl = "http://localhost:8081/songs";  // replace with actual Song Service URL
 
     @Autowired
-    public ResourceService(ResourceRepository resourceRepository) {
+    public ResourceService(
+            ResourceRepository resourceRepository,
+            Function<MultipartFile, Map<String, String>> metadataExtractor,
+            RestTemplate restTemplate) {
         this.resourceRepository = resourceRepository;
+        this.mp3MetadataExtractor = metadataExtractor;
+        this.restTemplate = restTemplate;
+    }
+
+    public Resource save(MultipartFile file) throws IOException {
+        var resource = new Resource();
+        resource.setData(file.getBytes());
+        var savedResource = resourceRepository.save(resource);
+
+        // Extract metadata from the file
+        var songMetadata = mp3MetadataExtractor.apply(file);
+
+        // Send a request to the Song Service to save the song metadata
+        restTemplate.postForObject(songServiceUrl, songMetadata, Void.class);
+
+        return savedResource;
     }
 
     public Resource save(Resource resource) {


### PR DESCRIPTION
Added functionality to extract song metadata using Tika library and save it in addition to the song file. The Resource Service can now handle mp3 files uploads, process the song metadata, and interact with the Song Service to store the metadata. Also introduced new components like SongMetadataMapper and TikaMetadataExtractor to support the metadata handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added metadata extraction for uploaded songs using Apache Tika.
  - Enhanced resource upload functionality to include metadata extraction and mapping.
  - Integrated with Song Service for metadata sharing.

- **Improvements**
  - Updated the resource upload endpoint to handle file saving more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->