### PR TITLE
Rename Eureka server application package

### DIFF
--- a/eureka-server/src/main/java/com/eurekaserver/application/EurekaServerApplication.java
+++ b/eureka-server/src/main/java/com/eurekaserver/application/EurekaServerApplication.java
@@ -1,4 +1,4 @@
-package com.epam.discoveryservice;
+package com.eurekaserver.application;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;


### PR DESCRIPTION
The package of Eureka server application has been renamed from com.epam.discoveryservice to com.eurekaserver.application. This was done for more concise and relevant package naming. For any service that depends on it, please update the package reference accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated package name from `com.epam.discoveryservice` to `com.eurekaserver.application` for better alignment with project naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->